### PR TITLE
ci: limit CodeQL concurrency per GOOS/GOARCH

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+# Copyright 2024 The mdlint Authors
+# SPDX-License-Identifier: MIT
+#
+# CodeQL analysis workflow with per-GOOS/GOARCH concurrency limit.
+---
+'name': CodeQL
+
+'on':
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
+    concurrency:
+      group: codeql-${{ matrix.goos }}-${{ matrix.goarch }}
+      cancel-in-progress: false
+    env:
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: go
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## Summary
- add CodeQL GitHub Actions workflow
- restrict CodeQL concurrency to one run for each GOOS/GOARCH pair

## Testing
- `yamllint .github/workflows/codeql.yml && echo "yamllint: OK"`


------
https://chatgpt.com/codex/tasks/task_b_68a21998033c83329854688f58e24809