### PR TITLE
feat: implement basic CLI and lint engine

### DIFF
--- a/cmd/mdlint/main.go
+++ b/cmd/mdlint/main.go
@@ -1,0 +1,84 @@
+// Copyright 2024 MdLint Authors
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/asymmetric-effort/mdlint/internal/config"
+	"github.com/asymmetric-effort/mdlint/internal/engine"
+	"github.com/asymmetric-effort/mdlint/internal/formatter"
+	"github.com/spf13/cobra"
+)
+
+const version = "0.1.0"
+
+func main() {
+	var (
+		cfgPath     string
+		quiet       bool
+		formatFlag  string
+		listRules   bool
+		showVersion bool
+	)
+	exitCode := 0
+	rootCmd := &cobra.Command{
+		Use:          "mdlint [files...]",
+		Short:        "mdlint lints Markdown files",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if quiet {
+				log.SetOutput(io.Discard)
+			}
+			if showVersion {
+				fmt.Fprintf(cmd.OutOrStdout(), "mdlint %s\n", version)
+				return nil
+			}
+			if listRules {
+				fmt.Fprintln(cmd.OutOrStdout(), "MD9000 TODO found")
+				return nil
+			}
+			cfg, err := config.Load(cfgPath)
+			if err != nil {
+				return err
+			}
+			if formatFlag != "" {
+				cfg.Format = formatFlag
+			}
+			eng := engine.Engine{}
+			fs, err := eng.Run(args)
+			if err != nil {
+				return err
+			}
+			if len(fs) == 0 {
+				return nil
+			}
+			out, err := formatter.Format(fs, cfg.Format)
+			if err != nil {
+				return err
+			}
+			if out != "" {
+				fmt.Fprint(cmd.OutOrStdout(), out)
+			}
+			if len(fs) > 0 {
+				exitCode = 1
+			}
+			return nil
+		},
+	}
+	rootCmd.Flags().StringVar(&cfgPath, "config", "", "config file")
+	rootCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "suppress logs")
+	rootCmd.Flags().StringVar(&formatFlag, "format", "", "output format")
+	rootCmd.Flags().BoolVar(&listRules, "list-rules", false, "list supported rules")
+	rootCmd.Flags().BoolVar(&showVersion, "version", false, "print version")
+	rootCmd.SilenceErrors = true
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	os.Exit(exitCode)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/asymmetric-effort/mdlint
+
+go 1.24
+
+require (
+	github.com/spf13/cobra v1.8.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
+github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,33 @@
+// Copyright 2024 MdLint Authors
+
+package config
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents linter configuration.
+type Config struct {
+	Format string `yaml:"format"`
+}
+
+// Load reads configuration from path or returns defaults when path is empty.
+func Load(path string) (*Config, error) {
+	cfg := &Config{Format: "json"}
+	if path == "" {
+		return cfg, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+	if cfg.Format == "" {
+		cfg.Format = "json"
+	}
+	return cfg, nil
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,0 +1,46 @@
+// Copyright 2024 MdLint Authors
+
+package engine
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/asymmetric-effort/mdlint/internal/findings"
+)
+
+// Engine executes lint rules.
+type Engine struct{}
+
+// Run processes files and returns findings.
+func (Engine) Run(paths []string) ([]findings.Finding, error) {
+	var result []findings.Finding
+	for _, p := range paths {
+		file, err := os.Open(p)
+		if err != nil {
+			return nil, err
+		}
+		scanner := bufio.NewScanner(file)
+		line := 1
+		for scanner.Scan() {
+			text := scanner.Text()
+			if idx := strings.Index(text, "TODO"); idx >= 0 {
+				result = append(result, findings.Finding{
+					Rule:    "MD9000",
+					Message: "TODO found",
+					File:    p,
+					Line:    line,
+					Column:  idx + 1,
+				})
+			}
+			line++
+		}
+		if err := scanner.Err(); err != nil {
+			_ = file.Close()
+			return nil, err
+		}
+		_ = file.Close()
+	}
+	return result, nil
+}

--- a/internal/findings/finding.go
+++ b/internal/findings/finding.go
@@ -1,0 +1,12 @@
+// Copyright 2024 MdLint Authors
+
+package findings
+
+// Finding represents a lint finding.
+type Finding struct {
+	Rule    string `json:"rule"`
+	Message string `json:"message"`
+	File    string `json:"file"`
+	Line    int    `json:"line"`
+	Column  int    `json:"column"`
+}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -1,0 +1,31 @@
+// Copyright 2024 MdLint Authors
+
+package formatter
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/asymmetric-effort/mdlint/internal/findings"
+)
+
+// Format returns formatted findings.
+func Format(fs []findings.Finding, format string) (string, error) {
+	switch format {
+	case "json":
+		b, err := json.Marshal(fs)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	case "text":
+		var sb strings.Builder
+		for _, f := range fs {
+			fmt.Fprintf(&sb, "%s:%d:%d %s %s\n", f.File, f.Line, f.Column, f.Rule, f.Message)
+		}
+		return sb.String(), nil
+	default:
+		return "", fmt.Errorf("unknown format %q", format)
+	}
+}

--- a/testdata/bad.md
+++ b/testdata/bad.md
@@ -1,0 +1,3 @@
+# Bad
+
+This has a TODO item.

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -1,0 +1,1 @@
+format: text

--- a/testdata/good.md
+++ b/testdata/good.md
@@ -1,0 +1,3 @@
+# Good
+
+This file has nothing to fix.

--- a/tests/cli_integration_test.go
+++ b/tests/cli_integration_test.go
@@ -1,0 +1,91 @@
+// Copyright 2024 MdLint Authors
+
+package tests
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// run executes the CLI with given arguments.
+func run(args ...string) (string, int, error) {
+	cmdArgs := append([]string{"run", "../cmd/mdlint"}, args...)
+	cmd := exec.Command("go", cmdArgs...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err := cmd.Run()
+	exit := 0
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			exit = ee.ExitCode()
+		} else {
+			return out.String(), -1, err
+		}
+	}
+	return out.String(), exit, nil
+}
+
+// TestCLI_NoFindings ensures exit code 0 when no issues.
+func TestCLI_NoFindings(t *testing.T) {
+	out, code, err := run("--format", "json", filepath.Join("..", "testdata", "good.md"))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if code != 0 {
+		t.Fatalf("expected exit 0 got %d output %s", code, out)
+	}
+	if out != "" {
+		t.Fatalf("expected no output got %s", out)
+	}
+}
+
+// TestCLI_Findings ensures exit code 1 when findings exist.
+func TestCLI_Findings(t *testing.T) {
+	out, code, err := run("--format", "json", filepath.Join("..", "testdata", "bad.md"))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if code != 1 {
+		t.Fatalf("expected exit 1 got %d output %s", code, out)
+	}
+}
+
+// TestCLI_ListRules ensures rules are listed.
+func TestCLI_ListRules(t *testing.T) {
+	out, code, err := run("--list-rules")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if code != 0 || !strings.Contains(out, "MD9000") {
+		t.Fatalf("unexpected: code %d output %s", code, out)
+	}
+}
+
+// TestCLI_Version ensures version flag prints version.
+func TestCLI_Version(t *testing.T) {
+	out, code, err := run("--version")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if code != 0 || !strings.Contains(out, "mdlint") {
+		t.Fatalf("unexpected: code %d output %s", code, out)
+	}
+}
+
+// TestCLI_ConfigFormat ensures config file controls formatting.
+func TestCLI_ConfigFormat(t *testing.T) {
+	out, code, err := run("--config", filepath.Join("..", "testdata", "config.yaml"), filepath.Join("..", "testdata", "bad.md"))
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if code != 1 {
+		t.Fatalf("expected exit 1 got %d output %s", code, out)
+	}
+	if !strings.Contains(out, "MD9000") || strings.HasPrefix(strings.TrimSpace(out), "[") {
+		t.Fatalf("expected text findings got %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add initial Cobra-based CLI with config, quiet, format, list-rules, and version flags
- wire stub engine, config loader, and formatter
- provide integration tests for CLI behaviour and exit codes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a2149802a48332a5c0928e8102e7be