### PR TITLE
feat: add formatters with golden tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/asymmetric-effort/mdlint
+
+go 1.24

--- a/internal/findings/finding.go
+++ b/internal/findings/finding.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2024
+
+package findings
+
+// Finding represents a single rule violation.
+type Finding struct {
+	Rule     string   `json:"rule"`
+	Severity Severity `json:"severity"`
+	Message  string   `json:"message"`
+	File     string   `json:"file"`
+	Line     int      `json:"line"`
+	Column   int      `json:"column"`
+}

--- a/internal/findings/severity.go
+++ b/internal/findings/severity.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2024
+
+package findings
+
+// Severity indicates rule violation severity.
+type Severity string
+
+const (
+	Suggestion Severity = "suggestion"
+	Warning    Severity = "warning"
+	Error      Severity = "error"
+)
+
+var severityRank = map[Severity]int{
+	Suggestion: 0,
+	Warning:    1,
+	Error:      2,
+}
+
+// String returns the string representation.
+func (s Severity) String() string { return string(s) }
+
+// AtLeast reports whether s is greater than or equal to threshold.
+func (s Severity) AtLeast(threshold Severity) bool {
+	return severityRank[s] >= severityRank[threshold]
+}

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2024
+
+package format_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/asymmetric-effort/mdlint/internal/findings"
+	formatpkg "github.com/asymmetric-effort/mdlint/internal/format"
+)
+
+var testFindings = []findings.Finding{
+	{File: "b.md", Line: 2, Column: 1, Rule: "MD1000", Severity: findings.Warning, Message: "warning 1"},
+	{File: "a.md", Line: 1, Column: 5, Rule: "MD1000", Severity: findings.Suggestion, Message: "suggestion 1"},
+	{File: "a.md", Line: 1, Column: 2, Rule: "MD1000", Severity: findings.Error, Message: "error 1"},
+	{File: "a.md", Line: 1, Column: 3, Rule: "MD1001", Severity: findings.Warning, Message: "warning 2"},
+	{File: "a.md", Line: 1, Column: 3, Rule: "MD1000", Severity: findings.Warning, Message: "warning 3"},
+	{File: "a.md", Line: 2, Column: 1, Rule: "MD1002", Severity: findings.Error, Message: "error 2"},
+}
+
+func TestFormatters(t *testing.T) {
+	t.Run("text_warning", func(t *testing.T) {
+		f := formatpkg.NewText(findings.Warning)
+		out, err := f.Format(testFindings)
+		if err != nil {
+			t.Fatalf("format: %v", err)
+		}
+		assertGolden(t, "testdata/text_warning.golden", out)
+	})
+
+	t.Run("text_suggestion", func(t *testing.T) {
+		f := formatpkg.NewText(findings.Suggestion)
+		out, err := f.Format(testFindings)
+		if err != nil {
+			t.Fatalf("format: %v", err)
+		}
+		assertGolden(t, "testdata/text_suggestion.golden", out)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		f := formatpkg.NewJSON()
+		out, err := f.Format(testFindings)
+		if err != nil {
+			t.Fatalf("format: %v", err)
+		}
+		assertGolden(t, "testdata/findings.json", out)
+	})
+}
+
+func assertGolden(t *testing.T, path string, got []byte) {
+	t.Helper()
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+		return
+	}
+	if string(want) != string(got) {
+		t.Fatalf("unexpected output:\nwant:\n%s\n---\ngot:\n%s", string(want), string(got))
+	}
+}

--- a/internal/format/formatter.go
+++ b/internal/format/formatter.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2024
+
+package format
+
+import (
+	"sort"
+
+	"github.com/asymmetric-effort/mdlint/internal/findings"
+)
+
+// Formatter outputs findings in a specific representation.
+type Formatter interface {
+	Format([]findings.Finding) ([]byte, error)
+}
+
+// sortFindings sorts the findings deterministically.
+func sortFindings(fs []findings.Finding) {
+	sort.Slice(fs, func(i, j int) bool {
+		a, b := fs[i], fs[j]
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Line != b.Line {
+			return a.Line < b.Line
+		}
+		if a.Column != b.Column {
+			return a.Column < b.Column
+		}
+		if a.Rule != b.Rule {
+			return a.Rule < b.Rule
+		}
+		return a.Message < b.Message
+	})
+}

--- a/internal/format/json.go
+++ b/internal/format/json.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2024
+
+package format
+
+import (
+	"encoding/json"
+
+	"github.com/asymmetric-effort/mdlint/internal/findings"
+)
+
+// JSON outputs findings as JSON array.
+type JSON struct{}
+
+// NewJSON creates a JSON formatter.
+func NewJSON() *JSON { return &JSON{} }
+
+// Format implements Formatter.
+func (j *JSON) Format(fs []findings.Finding) ([]byte, error) {
+	dup := make([]findings.Finding, len(fs))
+	copy(dup, fs)
+	sortFindings(dup)
+	b, err := json.MarshalIndent(dup, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(b, '\n'), nil
+}

--- a/internal/format/testdata/findings.json
+++ b/internal/format/testdata/findings.json
@@ -1,0 +1,50 @@
+[
+  {
+    "rule": "MD1000",
+    "severity": "error",
+    "message": "error 1",
+    "file": "a.md",
+    "line": 1,
+    "column": 2
+  },
+  {
+    "rule": "MD1000",
+    "severity": "warning",
+    "message": "warning 3",
+    "file": "a.md",
+    "line": 1,
+    "column": 3
+  },
+  {
+    "rule": "MD1001",
+    "severity": "warning",
+    "message": "warning 2",
+    "file": "a.md",
+    "line": 1,
+    "column": 3
+  },
+  {
+    "rule": "MD1000",
+    "severity": "suggestion",
+    "message": "suggestion 1",
+    "file": "a.md",
+    "line": 1,
+    "column": 5
+  },
+  {
+    "rule": "MD1002",
+    "severity": "error",
+    "message": "error 2",
+    "file": "a.md",
+    "line": 2,
+    "column": 1
+  },
+  {
+    "rule": "MD1000",
+    "severity": "warning",
+    "message": "warning 1",
+    "file": "b.md",
+    "line": 2,
+    "column": 1
+  }
+]

--- a/internal/format/testdata/text_suggestion.golden
+++ b/internal/format/testdata/text_suggestion.golden
@@ -1,0 +1,6 @@
+a.md:1:2 MD1000[error] error 1
+a.md:1:3 MD1000[warning] warning 3
+a.md:1:3 MD1001[warning] warning 2
+a.md:1:5 MD1000[suggestion] suggestion 1
+a.md:2:1 MD1002[error] error 2
+b.md:2:1 MD1000[warning] warning 1

--- a/internal/format/testdata/text_warning.golden
+++ b/internal/format/testdata/text_warning.golden
@@ -1,0 +1,5 @@
+a.md:1:2 MD1000[error] error 1
+a.md:1:3 MD1000[warning] warning 3
+a.md:1:3 MD1001[warning] warning 2
+a.md:2:1 MD1002[error] error 2
+b.md:2:1 MD1000[warning] warning 1

--- a/internal/format/text.go
+++ b/internal/format/text.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2024
+
+package format
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/asymmetric-effort/mdlint/internal/findings"
+)
+
+// Text outputs findings in human-readable text.
+type Text struct {
+	Threshold findings.Severity
+}
+
+// NewText creates a Text formatter.
+func NewText(threshold findings.Severity) *Text { return &Text{Threshold: threshold} }
+
+// Format implements Formatter.
+func (t *Text) Format(fs []findings.Finding) ([]byte, error) {
+	// Filter by threshold.
+	filtered := make([]findings.Finding, 0, len(fs))
+	for _, f := range fs {
+		if f.Severity.AtLeast(t.Threshold) {
+			filtered = append(filtered, f)
+		}
+	}
+	sortFindings(filtered)
+	var buf bytes.Buffer
+	for i, f := range filtered {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		fmt.Fprintf(&buf, "%s:%d:%d %s[%s] %s", f.File, f.Line, f.Column, f.Rule, f.Severity.String(), f.Message)
+	}
+	if buf.Len() > 0 {
+		buf.WriteByte('\n')
+	}
+	return buf.Bytes(), nil
+}


### PR DESCRIPTION
## Summary
- add formatter interfaces and deterministic sorting
- implement text formatter with severity threshold filter
- implement stable JSON formatter
- add golden tests for formatter outputs

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a214987578833294f4828a5a3fabc5