### PR TITLE
Add trailing whitespace rule with configurable code block ignore

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/asymmetric-effort/mdlint
+
+go 1.24

--- a/internal/rules/trailing_whitespace.go
+++ b/internal/rules/trailing_whitespace.go
@@ -1,0 +1,75 @@
+// Copyright 2024 the mdlint authors.
+
+package rules
+
+import (
+	"strings"
+)
+
+// Finding represents a rule violation.
+type Finding struct {
+	Line    int
+	Column  int
+	RuleID  string
+	Message string
+}
+
+// TrailingWhitespaceConfig configures the trailing whitespace rule.
+type TrailingWhitespaceConfig struct {
+	// IgnoreCodeBlocks controls whether lines inside fenced code blocks are checked.
+	// When true, lines within fenced code blocks are skipped.
+	IgnoreCodeBlocks bool
+}
+
+// CheckTrailingWhitespace scans content for trailing spaces or tabs.
+// It returns a list of findings for lines containing trailing whitespace.
+func CheckTrailingWhitespace(content []byte, cfg TrailingWhitespaceConfig) []Finding {
+	lines := strings.Split(string(content), "\n")
+	var findings []Finding
+	inCode := false
+	var fenceChar rune
+	for i, line := range lines {
+		// Remove trailing carriage return for Windows line endings.
+		line = strings.TrimSuffix(line, "\r")
+
+		trimmedLeft := strings.TrimLeft(line, " \t")
+		if f, ok := fenceMarker(trimmedLeft); ok {
+			if inCode {
+				if f == fenceChar {
+					inCode = false
+				}
+			} else {
+				inCode = true
+				fenceChar = f
+			}
+			if cfg.IgnoreCodeBlocks {
+				continue
+			}
+		}
+		if inCode && cfg.IgnoreCodeBlocks {
+			continue
+		}
+		if len(line) > 0 {
+			last := line[len(line)-1]
+			if last == ' ' || last == '\t' {
+				findings = append(findings, Finding{
+					Line:    i + 1,
+					Column:  len(line),
+					RuleID:  "MD1800",
+					Message: "line has trailing whitespace",
+				})
+			}
+		}
+	}
+	return findings
+}
+
+func fenceMarker(line string) (rune, bool) {
+	if strings.HasPrefix(line, "```") {
+		return '`', true
+	}
+	if strings.HasPrefix(line, "~~~") {
+		return '~', true
+	}
+	return 0, false
+}

--- a/internal/rules/trailing_whitespace_test.go
+++ b/internal/rules/trailing_whitespace_test.go
@@ -1,0 +1,52 @@
+// Copyright 2024 the mdlint authors.
+
+package rules
+
+import "testing"
+
+func TestCheckTrailingWhitespace(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		cfg     TrailingWhitespaceConfig
+		want    []int
+	}{
+		{
+			name:    "mixed whitespace with code block ignored",
+			content: "no trailing\nline with space \n```go\ncode line with space  \n```\nline with tab\t\n",
+			cfg:     TrailingWhitespaceConfig{IgnoreCodeBlocks: true},
+			want:    []int{2, 6},
+		},
+		{
+			name:    "check code blocks when not ignored",
+			content: "no trailing\nline with space \n```go\ncode line with space  \n```\nline with tab\t\n",
+			cfg:     TrailingWhitespaceConfig{IgnoreCodeBlocks: false},
+			want:    []int{2, 4, 6},
+		},
+		{
+			name:    "only code block when ignored",
+			content: "```go\ncode  \n```\n",
+			cfg:     TrailingWhitespaceConfig{IgnoreCodeBlocks: true},
+			want:    nil,
+		},
+		{
+			name:    "blank line with spaces",
+			content: "line\n   \nnext\n",
+			cfg:     TrailingWhitespaceConfig{IgnoreCodeBlocks: true},
+			want:    []int{2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CheckTrailingWhitespace([]byte(tt.content), tt.cfg)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d findings, want %d", len(got), len(tt.want))
+			}
+			for i, f := range got {
+				if f.Line != tt.want[i] {
+					t.Errorf("finding %d line = %d, want %d", i, f.Line, tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement MD1800 rule to flag trailing spaces or tabs
- add option to ignore fenced code blocks
- add unit tests for multiple whitespace scenarios

## Testing
- `go vet ./...`
- `time go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a21498f26c83328ead7f56cefecb8e