### PR TITLE
Add sequential heading level rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/asymmetric-effort/mdlint
+
+go 1.24
+
+require github.com/yuin/goldmark v1.7.13

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/internal/rules/md1100/md1100.go
+++ b/internal/rules/md1100/md1100.go
@@ -1,0 +1,87 @@
+// Package md1100 provides a rule checking sequential heading levels in Markdown.
+//
+// Copyright (c) 2025 Sam Caldwell
+package md1100
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// Config configures the MD1100 rule.
+type Config struct {
+	// Exclude lists section headings to ignore during validation.
+	Exclude []string
+}
+
+// Finding represents a heading level violation.
+type Finding struct {
+	// Line is the line number of the offending heading.
+	Line int
+	// Message describes the violation.
+	Message string
+}
+
+// CheckSequentialHeadings scans the Markdown document and reports headings that
+// increase by more than one level at a time. Sections whose heading text matches
+// cfg.Exclude are skipped entirely.
+func CheckSequentialHeadings(src []byte, cfg Config) []Finding {
+	md := goldmark.New()
+	root := md.Parser().Parse(text.NewReader(src))
+
+	var findings []Finding
+	var prevLevel int
+	var skipLevel int
+	var skipping bool
+
+	ast.Walk(root, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		heading, ok := n.(*ast.Heading)
+		if !ok || !entering {
+			return ast.WalkContinue, nil
+		}
+
+		title := string(heading.Text(src))
+		level := heading.Level
+
+		if skipping {
+			if level <= skipLevel {
+				skipping = false
+			} else {
+				return ast.WalkContinue, nil
+			}
+		}
+
+		if contains(cfg.Exclude, title) {
+			skipping = true
+			skipLevel = level
+			prevLevel = level
+			return ast.WalkContinue, nil
+		}
+
+		if prevLevel != 0 && level > prevLevel+1 {
+			seg := heading.Lines().At(0)
+			line := bytes.Count(src[:seg.Start], []byte("\n")) + 1
+			findings = append(findings, Finding{
+				Line:    line,
+				Message: "heading level should only increment by one level at a time",
+			})
+		}
+
+		prevLevel = level
+		return ast.WalkContinue, nil
+	})
+
+	return findings
+}
+
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/md1100/md1100_test.go
+++ b/internal/rules/md1100/md1100_test.go
@@ -1,0 +1,27 @@
+// Tests for MD1100 sequential heading rule.
+//
+// Copyright (c) 2025 Sam Caldwell
+package md1100
+
+import "testing"
+
+func TestCheckSequentialHeadingsValid(t *testing.T) {
+	src := []byte("# H1\n## H2\n### H3\n")
+	if f := CheckSequentialHeadings(src, Config{}); len(f) != 0 {
+		t.Fatalf("expected no findings, got %d", len(f))
+	}
+}
+
+func TestCheckSequentialHeadingsInvalid(t *testing.T) {
+	src := []byte("# H1\n### H3\n")
+	if f := CheckSequentialHeadings(src, Config{}); len(f) == 0 {
+		t.Fatalf("expected findings for non-sequential headings")
+	}
+}
+
+func TestCheckSequentialHeadingsExclude(t *testing.T) {
+	src := []byte("# Intro\n### Jump\n")
+	if f := CheckSequentialHeadings(src, Config{Exclude: []string{"Intro"}}); len(f) != 0 {
+		t.Fatalf("expected exclusion to skip findings, got %d", len(f))
+	}
+}


### PR DESCRIPTION
## Summary
- add MD1100 rule to flag non-sequential heading levels
- allow excluding sections from checks via configuration
- test valid, invalid, and excluded-section documents

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a2149dc770833291bbf2e6433ade6f