### PR TITLE
Add MD1000 maximum line length rule

### DIFF
--- a/docs/rules/MD1000.md
+++ b/docs/rules/MD1000.md
@@ -1,0 +1,29 @@
+# MD1000: Maximum Line Length
+
+Enforces a maximum number of characters per line in Markdown files. Lines exceeding the configured limit trigger a finding.
+
+## Configuration
+
+```yaml
+MD1000:
+  line_length: 80        # Maximum allowed characters per line
+  code_blocks: false     # If true, check lines inside fenced code blocks
+  tables: false          # If true, check lines inside tables
+```
+
+## Examples
+
+With `line_length: 10`:
+
+```markdown
+This line is fine
+This line is definitely too long
+```
+
+The second line produces:
+
+```
+README.md:2:11 MD1000 Line exceeds maximum length of 10 characters
+```
+
+Setting `code_blocks: true` or `tables: true` enables checking inside those structures.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,4 @@
+module github.com/asymmetric-effort/mdlint
+
+go 1.24
+

--- a/internal/engine/registry.go
+++ b/internal/engine/registry.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 The MdLint Authors.
+//
+// Package engine provides a simple rule registry and finding types.
+package engine
+
+// Rule defines the interface for linter rules.
+type Rule interface {
+	// ID returns the rule identifier, e.g. "MD1000".
+	ID() string
+	// Apply evaluates the rule against the provided Markdown content using
+	// the supplied configuration. The configuration type is rule specific.
+	Apply(content string, cfg any) []Finding
+}
+
+// Finding represents a single rule violation.
+type Finding struct {
+	Rule    string // Rule identifier.
+	Line    int    // 1-indexed line number.
+	Column  int    // 1-indexed column number.
+	Message string // Human-readable description of the issue.
+}
+
+var registry = map[string]Rule{}
+
+// RegisterRule adds a rule implementation to the registry.
+func RegisterRule(r Rule) {
+	registry[r.ID()] = r
+}
+
+// GetRule returns a registered rule by ID.
+func GetRule(id string) (Rule, bool) {
+	r, ok := registry[id]
+	return r, ok
+}
+
+// Rules returns all registered rules.
+func Rules() []Rule {
+	rs := make([]Rule, 0, len(registry))
+	for _, r := range registry {
+		rs = append(rs, r)
+	}
+	return rs
+}

--- a/internal/rules/md1000/md1000_test.go
+++ b/internal/rules/md1000/md1000_test.go
@@ -1,0 +1,63 @@
+package md1000_test
+
+import (
+	"testing"
+
+	"github.com/asymmetric-effort/mdlint/internal/engine"
+	"github.com/asymmetric-effort/mdlint/internal/rules/md1000"
+)
+
+func TestMD1000Rule_Basic(t *testing.T) {
+	rule, ok := engine.GetRule("MD1000")
+	if !ok {
+		t.Fatalf("MD1000 rule not registered")
+	}
+	cfg := md1000.Config{LineLength: 10}
+	content := "short\nthis line is way too long\n"
+	findings := rule.Apply(content, cfg)
+	if len(findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(findings))
+	}
+	if findings[0].Line != 2 {
+		t.Fatalf("expected finding on line 2, got %d", findings[0].Line)
+	}
+}
+
+func TestMD1000Rule_CodeBlockOption(t *testing.T) {
+	rule, _ := engine.GetRule("MD1000")
+	content := "```\nlong line inside code block that should not trigger\n```\n"
+	cfg := md1000.Config{LineLength: 10}
+	if f := rule.Apply(content, cfg); len(f) != 0 {
+		t.Fatalf("expected no findings when code blocks ignored, got %d", len(f))
+	}
+	cfg.CodeBlocks = true
+	if f := rule.Apply(content, cfg); len(f) != 1 {
+		t.Fatalf("expected finding when code blocks checked, got %d", len(f))
+	}
+}
+
+func TestMD1000Rule_TablesOption(t *testing.T) {
+	rule, _ := engine.GetRule("MD1000")
+	content := "|h1|h2|\n|-|-|\n| longlongline |ok|\n"
+	cfg := md1000.Config{LineLength: 10}
+	if f := rule.Apply(content, cfg); len(f) != 0 {
+		t.Fatalf("expected no findings when tables ignored, got %d", len(f))
+	}
+	cfg.Tables = true
+	if f := rule.Apply(content, cfg); len(f) != 1 {
+		t.Fatalf("expected finding when tables checked, got %d", len(f))
+	}
+}
+
+func TestMD1000Rule_Boundary(t *testing.T) {
+	rule, _ := engine.GetRule("MD1000")
+	cfg := md1000.Config{LineLength: 10}
+	content := "0123456789\n01234567890\n"
+	f := rule.Apply(content, cfg)
+	if len(f) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(f))
+	}
+	if f[0].Line != 2 {
+		t.Fatalf("expected finding on line 2, got %d", f[0].Line)
+	}
+}

--- a/internal/rules/md1000/rule.go
+++ b/internal/rules/md1000/rule.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2024 The MdLint Authors.
+//
+// Package md1000 implements a rule enforcing maximum line length in Markdown files.
+package md1000
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/asymmetric-effort/mdlint/internal/engine"
+)
+
+// Config configures the MD1000 rule.
+type Config struct {
+	LineLength int  // Maximum allowed line length. Defaults to 80.
+	CodeBlocks bool // Whether to enforce inside fenced code blocks.
+	Tables     bool // Whether to enforce inside tables.
+}
+
+// Rule implements the MD1000 maximum line length rule.
+type Rule struct{}
+
+// ensure Rule satisfies engine.Rule.
+var _ engine.Rule = Rule{}
+
+const defaultLineLength = 80
+
+// init registers the rule in the engine registry.
+func init() {
+	engine.RegisterRule(Rule{})
+}
+
+// ID returns the rule identifier.
+func (Rule) ID() string { return "MD1000" }
+
+// Apply checks the supplied Markdown content against the configured maximum
+// line length and returns any findings.
+func (Rule) Apply(content string, cfg any) []engine.Finding {
+	opts := Config{LineLength: defaultLineLength}
+	if c, ok := cfg.(Config); ok {
+		if c.LineLength > 0 {
+			opts.LineLength = c.LineLength
+		}
+		opts.CodeBlocks = c.CodeBlocks
+		opts.Tables = c.Tables
+	}
+
+	lines := strings.Split(content, "\n")
+	findings := []engine.Finding{}
+
+	inCode := false
+	inTable := false
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+
+		// Toggle fenced code blocks.
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inCode = !inCode
+			// Fences themselves are ignored.
+			continue
+		}
+
+		// Detect start of a table.
+		if !inCode && isTableHeader(i, lines) {
+			inTable = true
+		}
+		// Detect end of a table.
+		if inTable && (trimmed == "" || !strings.Contains(line, "|")) {
+			inTable = false
+		}
+
+		if (!opts.CodeBlocks && inCode) || (!opts.Tables && inTable) {
+			continue
+		}
+
+		if utf8.RuneCountInString(line) > opts.LineLength {
+			findings = append(findings, engine.Finding{
+				Rule:    "MD1000",
+				Line:    i + 1,
+				Column:  opts.LineLength + 1,
+				Message: fmt.Sprintf("Line exceeds maximum length of %d characters", opts.LineLength),
+			})
+		}
+	}
+
+	return findings
+}
+
+var tableSepRE = regexp.MustCompile(`^\s*\|?\s*[:\-]+[-\s:|]*\|`)
+
+// isTableHeader reports whether the line at index i begins a Markdown table.
+func isTableHeader(i int, lines []string) bool {
+	line := lines[i]
+	if !strings.Contains(line, "|") {
+		return false
+	}
+	if i+1 >= len(lines) {
+		return false
+	}
+	next := strings.TrimSpace(lines[i+1])
+	return tableSepRE.MatchString(next)
+}


### PR DESCRIPTION
## Summary
- add engine rule registry
- implement MD1000 max line length rule with configurable code block and table handling
- document MD1000 rule and provide unit tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a2149e49108332b62a329770a94002