### PR TITLE
feat: add markdown parser with skipping helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/asymmetric-effort/mdlint
+
+go 1.24.3
+
+require (
+	github.com/yuin/goldmark v1.7.13
+	github.com/yuin/goldmark-meta v1.1.0
+)
+
+require gopkg.in/yaml.v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
+github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark-meta v1.1.0 h1:pWw+JLHGZe8Rk0EGsMVssiNb/AaPMHfSRszZeUeiOUc=
+github.com/yuin/goldmark-meta v1.1.0/go.mod h1:U4spWENafuA7Zyg+Lj5RqK/MF+ovMYtBvXi1lBb2VP0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 Asymmetric Effort
+
+package markdown
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yuin/goldmark/text"
+)
+
+// helper to load testdata
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestFrontMatterRange(t *testing.T) {
+	src := readFixture(t, "basic.md")
+	rng, ok := FrontMatterRange(src)
+	if !ok {
+		t.Fatalf("expected front-matter range")
+	}
+	if rng.StartLine != 1 || rng.EndLine != 3 {
+		t.Fatalf("unexpected range: %#v", rng)
+	}
+}
+
+func TestCodeBlockRanges(t *testing.T) {
+	src := readFixture(t, "basic.md")
+	ranges := CodeBlockRanges(src)
+	if len(ranges) != 1 {
+		t.Fatalf("expected one code block, got %d", len(ranges))
+	}
+	if ranges[0].StartLine != 9 || ranges[0].EndLine != 11 {
+		t.Fatalf("unexpected range: %#v", ranges[0])
+	}
+}
+
+func TestParserSupportsExtensions(t *testing.T) {
+	src := readFixture(t, "basic.md")
+	md := Parser()
+	if md == nil {
+		t.Fatalf("Parser returned nil")
+	}
+	// parsing should succeed without panic
+	reader := text.NewReader(src)
+	if md.Parser().Parse(reader) == nil {
+		t.Fatalf("expected parsed document")
+	}
+}

--- a/internal/markdown/parser.go
+++ b/internal/markdown/parser.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2024 Asymmetric Effort
+
+package markdown
+
+import (
+	"sync"
+
+	"github.com/yuin/goldmark"
+	meta "github.com/yuin/goldmark-meta"
+	"github.com/yuin/goldmark/extension"
+)
+
+// parserOnce ensures singleton initialization of the Markdown parser.
+var parserOnce sync.Once
+
+// parserInstance holds the configured goldmark Markdown parser.
+var parserInstance goldmark.Markdown
+
+// Parser returns a goldmark Markdown parser configured with GFM, footnote,
+// table, and front-matter extensions. The parser is lazily initialized and
+// safe for concurrent use.
+func Parser() goldmark.Markdown {
+	parserOnce.Do(func() {
+		parserInstance = goldmark.New(
+			goldmark.WithExtensions(
+				extension.GFM,
+				extension.Footnote,
+				extension.Table,
+				meta.Meta,
+			),
+		)
+	})
+	return parserInstance
+}

--- a/internal/markdown/range.go
+++ b/internal/markdown/range.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2024 Asymmetric Effort
+
+package markdown
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/text"
+)
+
+// Range represents an inclusive line range within a Markdown document.
+type Range struct {
+	StartLine int // 1-based line number where the range starts
+	EndLine   int // 1-based line number where the range ends
+}
+
+// CodeBlockRanges returns line ranges for all code blocks in the provided source.
+// Ranges include fenced and indented code blocks.
+func CodeBlockRanges(src []byte) []Range {
+	md := Parser()
+	reader := text.NewReader(src)
+	doc := md.Parser().Parse(reader)
+
+	var ranges []Range
+	ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+		switch n := n.(type) {
+		case *ast.FencedCodeBlock:
+			lines := n.Lines()
+			if lines == nil || lines.Len() == 0 {
+				return ast.WalkContinue, nil
+			}
+			first := lines.At(0)
+			last := lines.At(lines.Len() - 1)
+			start := lineNumber(src, first.Start) - 1
+			if start < 1 {
+				start = 1
+			}
+			end := lineNumber(src, last.Stop)
+			ranges = append(ranges, Range{StartLine: start, EndLine: end})
+			return ast.WalkSkipChildren, nil
+		case *ast.CodeBlock:
+			lines := n.Lines()
+			if lines == nil || lines.Len() == 0 {
+				return ast.WalkContinue, nil
+			}
+			first := lines.At(0)
+			last := lines.At(lines.Len() - 1)
+			ranges = append(ranges, Range{
+				StartLine: lineNumber(src, first.Start),
+				EndLine:   lineNumber(src, last.Stop),
+			})
+			return ast.WalkSkipChildren, nil
+		}
+		return ast.WalkContinue, nil
+	})
+	return ranges
+}
+
+// FrontMatterRange returns the line range for a leading YAML front-matter
+// section. If no front-matter is present, ok will be false.
+func FrontMatterRange(src []byte) (rng Range, ok bool) {
+	lines := bytes.Split(src, []byte("\n"))
+	if len(lines) == 0 {
+		return Range{}, false
+	}
+	if !bytes.Equal(bytes.TrimSpace(lines[0]), []byte("---")) {
+		return Range{}, false
+	}
+	for i := 1; i < len(lines); i++ {
+		if bytes.Equal(bytes.TrimSpace(lines[i]), []byte("---")) {
+			return Range{StartLine: 1, EndLine: i + 1}, true
+		}
+	}
+	return Range{}, false
+}
+
+// lineNumber converts a byte offset into a 1-based line number.
+func lineNumber(src []byte, pos int) int {
+	return bytes.Count(src[:pos], []byte("\n")) + 1
+}

--- a/internal/markdown/testdata/basic.md
+++ b/internal/markdown/testdata/basic.md
@@ -1,0 +1,13 @@
+---
+title: Example
+---
+
+# Heading
+
+Paragraph with some text.
+
+```go
+fmt.Println("hello")
+```
+
+Another paragraph.


### PR DESCRIPTION
## Summary
- add markdown parser leveraging goldmark with GFM, footnote, table and front-matter extensions
- provide helpers to identify code blocks and front-matter regions
- cover parser and helpers with markdown fixtures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a214a0181c8332a44945289813490d