### PR TITLE
feat: add configuration loader with validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/asymmetric-effort/mdlint
+
+go 1.24.3
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,252 @@
+// Copyright 2024 The mdlint Authors
+// SPDX-License-Identifier: MIT
+
+// Package config provides loading and validation for mdlint configuration.
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Severity represents a rule severity level.
+type Severity string
+
+// Config holds the top-level configuration for mdlint.
+type Config struct {
+	Version          int                   `yaml:"version"`
+	Ignored          []string              `yaml:"ignored"`
+	Severity         map[string]Severity   `yaml:"severity"`
+	Paths            map[string]PathConfig `yaml:"paths"`
+	Spell            SpellConfig           `yaml:"spell"`
+	Heading          HeadingConfig         `yaml:"heading"`
+	Output           OutputConfig          `yaml:"output"`
+	FailureThreshold Severity              `yaml:"failure_threshold"`
+}
+
+// PathConfig defines per-path overrides.
+type PathConfig struct {
+	Ignored  []string            `yaml:"ignored"`
+	Severity map[string]Severity `yaml:"severity"`
+}
+
+// SpellConfig defines options for the spelling rule MD1000.
+type SpellConfig struct {
+	Lang        string   `yaml:"lang"`
+	AddWords    []string `yaml:"add_words"`
+	RejectWords []string `yaml:"reject_words"`
+	Filters     []string `yaml:"filters"`
+}
+
+// HeadingConfig defines options for heading style checks.
+type HeadingConfig struct {
+	Style      string `yaml:"style"`
+	AllowMixed *bool  `yaml:"allow_mixed"`
+}
+
+// OutputConfig defines formatting options for findings output.
+type OutputConfig struct {
+	Format string `yaml:"format"`
+	Color  string `yaml:"color"`
+}
+
+// DefaultConfig returns configuration with built-in defaults.
+func DefaultConfig() Config {
+	allowMixed := false
+	return Config{
+		Version:          1,
+		Output:           OutputConfig{Format: "json", Color: "auto"},
+		Heading:          HeadingConfig{AllowMixed: &allowMixed},
+		FailureThreshold: "warning",
+	}
+}
+
+// Load resolves configuration from user, project and CLI sources in precedence order.
+// CLI overrides are provided via the cli parameter; projectDir determines where the
+// project configuration file is looked up.
+func Load(cli Config, projectDir string) (Config, error) {
+	cfg := DefaultConfig()
+
+	if userCfg, err := readConfigFile(userConfigPath()); err == nil {
+		merge(&cfg, userCfg)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return Config{}, err
+	}
+
+	if projectDir != "" {
+		projPath := filepath.Join(projectDir, ".mdlintrc.yaml")
+		if projCfg, err := readConfigFile(projPath); err == nil {
+			merge(&cfg, projCfg)
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return Config{}, err
+		}
+	}
+
+	merge(&cfg, cli)
+
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
+}
+
+func readConfigFile(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	cfg, err := parseYAML(data)
+	if err != nil {
+		return Config{}, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func parseYAML(data []byte) (Config, error) {
+	var cfg Config
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// Validate performs custom schema checks beyond YAML decoding.
+func (c Config) Validate() error {
+	if c.Version != 1 {
+		return fmt.Errorf("unsupported version %d", c.Version)
+	}
+
+	validSev := map[Severity]bool{"suggestion": true, "warning": true, "error": true}
+	checkSev := func(sev Severity) error {
+		if sev == "" {
+			return nil
+		}
+		if !validSev[sev] {
+			return fmt.Errorf("invalid severity %q", sev)
+		}
+		return nil
+	}
+
+	for _, sev := range c.Severity {
+		if err := checkSev(sev); err != nil {
+			return err
+		}
+	}
+	for _, pc := range c.Paths {
+		for _, sev := range pc.Severity {
+			if err := checkSev(sev); err != nil {
+				return err
+			}
+		}
+	}
+
+	if c.Heading.Style != "" {
+		switch c.Heading.Style {
+		case "atx", "setext", "consistent":
+		default:
+			return fmt.Errorf("invalid heading style %q", c.Heading.Style)
+		}
+	}
+
+	switch c.Output.Format {
+	case "", "json", "text":
+	default:
+		return fmt.Errorf("invalid output format %q", c.Output.Format)
+	}
+	switch c.Output.Color {
+	case "", "auto", "always", "never":
+	default:
+		return fmt.Errorf("invalid output color %q", c.Output.Color)
+	}
+
+	if err := checkSev(c.FailureThreshold); err != nil {
+		return fmt.Errorf("invalid failure threshold: %w", err)
+	}
+	return nil
+}
+
+func merge(dst *Config, src Config) {
+	if src.Version != 0 {
+		dst.Version = src.Version
+	}
+	if len(src.Ignored) > 0 {
+		dst.Ignored = append(dst.Ignored, src.Ignored...)
+	}
+	if src.Severity != nil {
+		if dst.Severity == nil {
+			dst.Severity = make(map[string]Severity)
+		}
+		for k, v := range src.Severity {
+			dst.Severity[k] = v
+		}
+	}
+	if src.Paths != nil {
+		if dst.Paths == nil {
+			dst.Paths = make(map[string]PathConfig)
+		}
+		for p, pc := range src.Paths {
+			existing := dst.Paths[p]
+			if len(pc.Ignored) > 0 {
+				existing.Ignored = append(existing.Ignored, pc.Ignored...)
+			}
+			if pc.Severity != nil {
+				if existing.Severity == nil {
+					existing.Severity = make(map[string]Severity)
+				}
+				for rk, rv := range pc.Severity {
+					existing.Severity[rk] = rv
+				}
+			}
+			dst.Paths[p] = existing
+		}
+	}
+	if src.Spell.Lang != "" {
+		dst.Spell.Lang = src.Spell.Lang
+	}
+	if len(src.Spell.AddWords) > 0 {
+		dst.Spell.AddWords = append(dst.Spell.AddWords, src.Spell.AddWords...)
+	}
+	if len(src.Spell.RejectWords) > 0 {
+		dst.Spell.RejectWords = append(dst.Spell.RejectWords, src.Spell.RejectWords...)
+	}
+	if len(src.Spell.Filters) > 0 {
+		dst.Spell.Filters = append(dst.Spell.Filters, src.Spell.Filters...)
+	}
+	if src.Heading.Style != "" {
+		dst.Heading.Style = src.Heading.Style
+	}
+	if src.Heading.AllowMixed != nil {
+		dst.Heading.AllowMixed = src.Heading.AllowMixed
+	}
+	if src.Output.Format != "" {
+		dst.Output.Format = src.Output.Format
+	}
+	if src.Output.Color != "" {
+		dst.Output.Color = src.Output.Color
+	}
+	if src.FailureThreshold != "" {
+		dst.FailureThreshold = src.FailureThreshold
+	}
+}
+
+func userConfigPath() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "mdlint", "config.yaml")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "config.yaml"
+	}
+	return filepath.Join(home, ".config", "mdlint", "config.yaml")
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadDefault verifies that defaults are applied when no configuration files are present.
+func TestLoadDefault(t *testing.T) {
+	cfg, err := Load(Config{}, "")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.Version != 1 {
+		t.Fatalf("unexpected version %d", cfg.Version)
+	}
+	if cfg.Output.Format != "json" || cfg.Output.Color != "auto" {
+		t.Fatalf("unexpected output defaults: %+v", cfg.Output)
+	}
+	if cfg.FailureThreshold != "warning" {
+		t.Fatalf("unexpected failure threshold %q", cfg.FailureThreshold)
+	}
+}
+
+// TestLoadMergePrecedence ensures CLI overrides project config which overrides user config.
+func TestLoadMergePrecedence(t *testing.T) {
+	tmp := t.TempDir()
+
+	// user config
+	userCfgDir := filepath.Join(tmp, "user", "mdlint")
+	if err := os.MkdirAll(userCfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userCfgDir, "config.yaml"), []byte("version: 1\noutput:\n  color: always\nfailure_threshold: suggestion\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "user"))
+
+	// project config
+	projDir := filepath.Join(tmp, "proj")
+	if err := os.MkdirAll(projDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projDir, ".mdlintrc.yaml"), []byte("version: 1\noutput:\n  color: never\nfailure_threshold: warning\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := Config{FailureThreshold: "error"}
+	cfg, err := Load(cli, projDir)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.FailureThreshold != "error" {
+		t.Fatalf("expected CLI to override failure threshold, got %q", cfg.FailureThreshold)
+	}
+	if cfg.Output.Color != "never" {
+		t.Fatalf("expected project config to override user output color, got %q", cfg.Output.Color)
+	}
+}
+
+// TestLoadValidationError ensures invalid config values are rejected.
+func TestLoadValidationError(t *testing.T) {
+	tmp := t.TempDir()
+	userCfgDir := filepath.Join(tmp, "mdlint")
+	if err := os.MkdirAll(userCfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// invalid output format
+	if err := os.WriteFile(filepath.Join(userCfgDir, "config.yaml"), []byte("version: 1\noutput:\n  format: xml\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if _, err := Load(Config{}, ""); err == nil {
+		t.Fatalf("expected error for invalid output format")
+	}
+
+	// unknown field
+	if err := os.WriteFile(filepath.Join(userCfgDir, "config.yaml"), []byte("version: 1\nunknown: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(Config{}, ""); err == nil {
+		t.Fatalf("expected error for unknown field")
+	}
+}


### PR DESCRIPTION
## Summary
- define Config struct and defaults
- implement Load with CLI > project .mdlintrc.yaml > user config precedence
- add strict YAML decoding and custom schema validation
- test merge precedence, defaults, and validation errors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a214a0f26c833293e7b2982d627e9a