### PR TITLE
chore: scaffold project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+# Copyright 2025 Sam Caldwell
+# SPDX-License-Identifier: MIT
+
+.PHONY: build lint test release
+
+build:
+	go build ./...
+
+lint:
+	go fmt ./...
+	go vet ./...
+
+test:
+	go test ./...
+
+release:
+	go build -ldflags "-s -w" -o bin/mdlint cmd/mdlint/main.go

--- a/cmd/mdlint/main.go
+++ b/cmd/mdlint/main.go
@@ -1,0 +1,10 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+// Package main provides the command-line interface for mdlint.
+package main
+
+// main is the entry point for the mdlint CLI.
+func main() {
+	// Placeholder for CLI implementation.
+}

--- a/cmd/mdlint/main_test.go
+++ b/cmd/mdlint/main_test.go
@@ -1,0 +1,11 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+package main
+
+import "testing"
+
+// TestMain ensures the main function executes without error.
+func TestMain(t *testing.T) {
+	main()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,6 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+module github.com/OWNER/mdlint
+
+go 1.24.3

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,9 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+package config
+
+import "testing"
+
+// TestPlaceholder verifies the config package compiles.
+func TestPlaceholder(t *testing.T) {}

--- a/internal/config/doc.go
+++ b/internal/config/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+// Package config provides TODO documentation.
+package config

--- a/internal/engine/doc.go
+++ b/internal/engine/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+// Package engine provides TODO documentation.
+package engine

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -1,0 +1,9 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+package engine
+
+import "testing"
+
+// TestPlaceholder verifies the engine package compiles.
+func TestPlaceholder(t *testing.T) {}

--- a/internal/format/doc.go
+++ b/internal/format/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+// Package format provides TODO documentation.
+package format

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,0 +1,9 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+package format
+
+import "testing"
+
+// TestPlaceholder verifies the format package compiles.
+func TestPlaceholder(t *testing.T) {}

--- a/internal/markdown/doc.go
+++ b/internal/markdown/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+// Package markdown provides TODO documentation.
+package markdown

--- a/internal/markdown/markdown_test.go
+++ b/internal/markdown/markdown_test.go
@@ -1,0 +1,9 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+package markdown
+
+import "testing"
+
+// TestPlaceholder verifies the markdown package compiles.
+func TestPlaceholder(t *testing.T) {}

--- a/internal/rules/doc.go
+++ b/internal/rules/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+// Package rules provides TODO documentation.
+package rules

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -1,0 +1,9 @@
+// Copyright 2025 Sam Caldwell
+// SPDX-License-Identifier: MIT
+
+package rules
+
+import "testing"
+
+// TestPlaceholder verifies the rules package compiles.
+func TestPlaceholder(t *testing.T) {}


### PR DESCRIPTION
## Summary
- initialize Go module and project structure
- add CLI entrypoint and internal package placeholders
- provide Makefile with build, lint, test, and release targets

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a214a503d08332a50545cd8e7a6c72