### PR TITLE
docs: expand usage and rule references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,72 @@
-MdLint
-======
+# MdLint
 
 ![MdLint icon](docs/img/logo.png)
 
+MdLint is a fast, extensible Markdown linter written in Go.
+
+## Installation
+
+```bash
+go install github.com/asymmetric-effort/mdlint@latest
+```
+
+Binaries for Linux, macOS, and Windows are available on the [releases page](https://github.com/asymmetric-effort/mdlint/releases).
+
+## Usage
+
+```bash
+mdlint [flags] <path|glob>...
+```
+
+Common flags:
+
+| Flag | Description |
+| --- | --- |
+| `-c, --config <file>` | Use a specific config file |
+| `-o, --output <format>` | Output format: `json` or `text` |
+| `--fail-level <sev>` | Minimum severity that causes a non-zero exit |
+
+## Configuration
+
+MdLint reads options from `.mdlintrc.yaml` in your project root. Example:
+
+```yaml
+version: 1
+ignored:
+  - MD1500
+severity:
+  MD1100: error
+paths:
+  "docs/**":
+    ignored: [MD1400]
+spell:
+  lang: en_US
+  add_words: [GoLand]
+heading:
+  style: atx
+  allow_mixed: false
+failure_threshold: warning
+```
+
+## Pre-commit
+
+Use MdLint as a [pre-commit](https://pre-commit.com/) hook:
+
+```yaml
+repos:
+  - repo: https://github.com/asymmetric-effort/mdlint
+    rev: v1.0.0
+    hooks:
+      - id: mdlint
+        args: ["--fail-level", "warning"]
+```
+
+## Editor Integration
+
+* **VS Code:** add a task running `mdlint` and enable the problem matcher.
+* **JetBrains IDEs:** configure `mdlint` as an External Tool and enable
+  "Show in output".
+
+## Built-in Rules
+
+Rule documentation is generated from source annotations. See the [rule reference](docs/rules.md).

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,0 +1,10 @@
+<!-- markdownlint-disable MD013 -->
+# Built-in Rules
+
+| ID | Name | Summary | Default Severity | Options |
+| --- | --- | --- | --- | --- |
+| MD1000 | Spelling | Flags tokens not found in configured dictionaries. | warning | lang, add_words, reject_words, filters |
+| MD1100 | Consistent Heading Style | Enforces atx, setext, or consistent heading style within a document. | error | style, allow_mixed |
+| MD1400 | Repetition | Detects adjacent repeated words and near duplicates. | warning | distance |
+| MD1500 | Consistency (Preferred Terms) | Enforces consistent terminology based on project vocabulary mappings. | warning | terms |
+<!-- markdownlint-enable MD013 -->

--- a/internal/rules/md1000_spelling.go
+++ b/internal/rules/md1000_spelling.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2024 MdLint contributors.
+// SPDX-License-Identifier: MIT
+
+// Package rules contains built-in Markdown lint rules.
+package rules
+
+// RuleID: MD1000
+// Name: Spelling
+// Summary: Flags tokens not found in configured dictionaries.
+// Severity: warning
+// Options: lang, add_words, reject_words, filters

--- a/internal/rules/md1100_heading_style.go
+++ b/internal/rules/md1100_heading_style.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2024 MdLint contributors.
+// SPDX-License-Identifier: MIT
+
+package rules
+
+// RuleID: MD1100
+// Name: Consistent Heading Style
+// Summary: Enforces atx, setext, or consistent heading style within a document.
+// Severity: error
+// Options: style, allow_mixed

--- a/internal/rules/md1400_repetition.go
+++ b/internal/rules/md1400_repetition.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2024 MdLint contributors.
+// SPDX-License-Identifier: MIT
+
+package rules
+
+// RuleID: MD1400
+// Name: Repetition
+// Summary: Detects adjacent repeated words and near duplicates.
+// Severity: warning
+// Options: distance

--- a/internal/rules/md1500_preferred_terms.go
+++ b/internal/rules/md1500_preferred_terms.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2024 MdLint contributors.
+// SPDX-License-Identifier: MIT
+
+package rules
+
+// RuleID: MD1500
+// Name: Consistency (Preferred Terms)
+// Summary: Enforces consistent terminology based on project vocabulary mappings.
+// Severity: warning
+// Options: terms

--- a/scripts/gen_rule_table.py
+++ b/scripts/gen_rule_table.py
@@ -1,0 +1,80 @@
+"""Generate Markdown rule reference tables from annotated Go rule files."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+# Copyright (c) 2024 MdLint contributors.
+# SPDX-License-Identifier: MIT
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RULES_DIR = ROOT / "internal" / "rules"
+DOC_PATH = ROOT / "docs" / "rules.md"
+
+
+@dataclass
+class Rule:
+    """Metadata about a single lint rule."""
+
+    rule_id: str
+    name: str
+    summary: str
+    severity: str
+    options: str
+
+
+def parse_rule_file(path: pathlib.Path) -> Rule:
+    """Parse a Go rule file and extract rule metadata."""
+    text = path.read_text(encoding="utf-8")
+    data = {}
+    for key in ("RuleID", "Name", "Summary", "Severity", "Options"):
+        match = re.search(rf"^// {key}: (.+)$", text, re.MULTILINE)
+        if not match:
+            raise ValueError(f"missing {key} in {path}")
+        data[key.lower()] = match.group(1).strip()
+    return Rule(
+        rule_id=data["ruleid"],
+        name=data["name"],
+        summary=data["summary"],
+        severity=data["severity"],
+        options=data["options"],
+    )
+
+
+def load_rules(directory: pathlib.Path) -> List[Rule]:
+    """Load all rule files from the provided directory."""
+    rules: List[Rule] = []
+    for path in sorted(directory.glob("md*.go")):
+        rules.append(parse_rule_file(path))
+    return rules
+
+
+def render_table(rules: Iterable[Rule]) -> str:
+    """Render a Markdown table of rules."""
+    header = "| ID | Name | Summary | Default Severity | Options |\n| --- | --- | --- | --- | --- |"
+    rows = [
+        f"| {r.rule_id} | {r.name} | {r.summary} | {r.severity} | {r.options} |"
+        for r in rules
+    ]
+    return "\n".join([header, *rows])
+
+
+def main() -> None:
+    """Entry point for the script."""
+    rules = load_rules(RULES_DIR)
+    table = render_table(rules)
+    content = (
+        "<!-- markdownlint-disable MD013 -->\n"
+        "# Built-in Rules\n\n"
+        + table
+        + "\n<!-- markdownlint-enable MD013 -->\n"
+    )
+    DOC_PATH.write_text(content, encoding="utf-8")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/test_gen_rule_table.py
+++ b/scripts/test_gen_rule_table.py
@@ -1,0 +1,21 @@
+"""Tests for rule table generation script."""
+
+# Copyright (c) 2024 MdLint contributors.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+from gen_rule_table import load_rules, render_table
+
+
+def test_load_rules(tmp_path: Path) -> None:
+    rules = load_rules(Path(__file__).resolve().parents[1] / "internal" / "rules")
+    ids = [r.rule_id for r in rules]
+    assert "MD1000" in ids and "MD1500" in ids
+
+
+def test_render_table() -> None:
+    rules = load_rules(Path(__file__).resolve().parents[1] / "internal" / "rules")
+    table = render_table(rules)
+    assert "MD1100" in table
+    assert table.count("|") > 10


### PR DESCRIPTION
## Summary
- document installation, usage, config, pre-commit, and editor notes
- generate rule reference table from annotated Go files
- add script and tests for rule table generation

## Testing
- `pytest -q`
- `markdownlint README.md docs/rules.md`


------
https://chatgpt.com/codex/tasks/task_b_68a214936cd48332a29fe8256839ede3