### PR TITLE
feat: add version flag and release tooling

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,23 @@
+name: Changelog
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate changelog
+        run: |
+          last_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          git log --pretty=format:'* %s (%h)' ${last_tag}..HEAD > CHANGELOG.md
+      - name: Upload changelog
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog
+          path: CHANGELOG.md
+

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+# Goreleaser configuration for mdlint.
+#
+# This file defines how binaries are built and published.
+project_name: mdlint
+
+builds:
+  - id: mdlint
+    main: ./cmd/mdlint
+    binary: mdlint
+    ldflags:
+      - -s -w
+      - -X github.com/sam-caldwell/mdlint/internal/version.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    files:
+      - LICENSE
+      - README.md
+
+changelog:
+  use: git
+
+release:
+  github:
+    owner: sam-caldwell
+    name: mdlint
+

--- a/cmd/mdlint/main.go
+++ b/cmd/mdlint/main.go
@@ -1,0 +1,22 @@
+// Copyright 2025 Sam Caldwell
+//
+// MdLint is a command-line application for linting Markdown files.
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/sam-caldwell/mdlint/internal/version"
+)
+
+// main is the application entry point.
+func main() {
+	showVersion := flag.Bool("version", false, "Print application version and exit")
+	flag.Parse()
+	if *showVersion {
+		fmt.Println(version.Version)
+		return
+	}
+	// TODO: implement CLI
+}

--- a/cmd/mdlint/main_test.go
+++ b/cmd/mdlint/main_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Sam Caldwell
+//
+// Tests for the mdlint command-line interface.
+package main_test
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+
+	"github.com/sam-caldwell/mdlint/internal/version"
+)
+
+// TestVersionFlag verifies that the --version flag prints the semantic version.
+func TestVersionFlag(t *testing.T) {
+	cmd := exec.Command("go", "run", ".", "--version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("command failed: %v output: %s", err, out.String())
+	}
+	expected := version.Version + "\n"
+	if out.String() != expected {
+		t.Fatalf("expected %q got %q", expected, out.String())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/sam-caldwell/mdlint
+
+go 1.24.3

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,9 @@
+// Copyright 2025 Sam Caldwell
+//
+// Package version provides the mdlint semantic version string.
+package version
+
+// Version is the semantic version of the mdlint application.
+//
+// This value should follow semantic versioning rules.
+var Version = "0.1.0"


### PR DESCRIPTION
## Summary
- add semantic version constant and version flag for CLI
- configure GoReleaser to build and publish binaries
- add changelog generation workflow
- test version flag output

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68a2149257cc8332a885d095a7e57e84